### PR TITLE
Add JDK 25 images

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8, 11, 17, 21]
+        version: [8, 11, 17, 21, 25]
         vendor: [temurin, semeru, graalvm]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Currently built versions with their vendors are Eclipse Temurin, IBM Semeru, and
     * `ghcr.io/pizzabytellc/images:java_21-semeru`
   * [`java21-graalvm`](/java/21/graalvm/Dockerfile)
     * `ghcr.io/pizzabytellc/images:java_21-graalvm`
+* [`java25`](/java/25/)
+  * [`java25-temurin`](/java/25/temurin/Dockerfile)
+    * `ghcr.io/pizzabytellc/images:java_25-temurin`
+  * [`java25-semeru`](/java/25/semeru/Dockerfile)
+    * `ghcr.io/pizzabytellc/images:java_25-semeru`
+  * [`java25-graalvm`](/java/25/graalvm/Dockerfile)
+    * `ghcr.io/pizzabytellc/images:java_25-graalvm`
 
 ### [Installation Images](/installers)
 

--- a/java/25/graalvm/Dockerfile
+++ b/java/25/graalvm/Dockerfile
@@ -1,0 +1,57 @@
+FROM        --platform=$TARGETOS/$TARGETARCH ubuntu:noble
+
+LABEL       author="Garrett Summerfield" maintainer="garrett@pizzabyte.net"
+
+LABEL       org.opencontainers.image.source="https://github.com/PizzabyteLLC/images"
+LABEL       org.opencontainers.image.licenses=MIT
+
+ARG         TARGETPLATFORM
+ARG         GRAAL_VERSION=25.0.1
+ARG         JAVA_VERSION=25
+
+RUN         apt update \
+            && apt install -y \
+                curl \
+                lsof \
+                ca-certificates \
+                openssl \
+                git \
+                tar \
+                sqlite3 \
+                fontconfig \
+                tzdata \
+                iproute2 \
+                libfreetype6 \
+                tini \
+                zip \
+                unzip \
+                libstdc++6
+
+
+RUN         case ${TARGETPLATFORM} in \
+                "linux/amd64")  ARCH=x64  ;; \
+                "linux/arm64")  ARCH=aarch64  ;; \
+                esac \
+            && curl --retry 3 -Lfso /tmp/graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/graalvm-community-jdk-${GRAAL_VERSION}_linux-${ARCH}_bin.tar.gz \
+            && mkdir -p /opt/java/graalvm \
+            && cd /opt/java/graalvm \
+            && tar -xf /tmp/graalvm.tar.gz --strip-components=1 \
+            && export PATH="/opt/java/graalvm/bin:$PATH" \
+            && rm -rf /var/lib/apt/lists/* \
+            && rm -rf /tmp/graalvm.tar.gz
+
+ENV        JAVA_HOME=/opt/java/graalvm
+ENV        PATH="$PATH:/opt/java/graalvm/bin"
+
+## Setup user and working directory
+RUN         useradd -m -d /home/container container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container ./../../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]

--- a/java/25/semeru/Dockerfile
+++ b/java/25/semeru/Dockerfile
@@ -1,0 +1,37 @@
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-25-jdk
+
+LABEL       author="Garrett Summerfield" maintainer="garrett@pizzabyte.net"
+
+LABEL       org.opencontainers.image.source="https://github.com/PizzabyteLLC/images"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN         apt update -y \
+            && apt install -y \
+                curl \
+                lsof \
+                ca-certificates \
+                openssl \
+                git \
+                tar \
+                sqlite3 \
+                fontconfig \
+                tzdata \
+                iproute2 \
+                libfreetype6 \
+                tini \
+                zip \
+                unzip \
+                libstdc++6
+
+## Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container ./../../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]

--- a/java/25/temurin/Dockerfile
+++ b/java/25/temurin/Dockerfile
@@ -1,0 +1,37 @@
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:25-jdk-noble
+
+LABEL       author="Garrett Summerfield" maintainer="garrett@pizzabyte.net"
+
+LABEL       org.opencontainers.image.source="https://github.com/PizzabyteLLC/images"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN         apt update -y \
+            && apt install -y \
+                curl \
+                lsof \
+                ca-certificates \
+                openssl \
+                git \
+                tar \
+                sqlite3 \
+                fontconfig \
+                tzdata \
+                iproute2 \
+                libfreetype6 \
+                tini \
+                zip \
+                unzip \
+                libstdc++6
+
+## Setup user and working directory
+RUN         useradd -m -d /home/container -s /bin/bash container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container ./../../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]


### PR DESCRIPTION
Java 25 has been released. Docker images have been created from major vendors, which have been adapted for Pterodactyl/Pelican.

Temurin, Semeru, and GraalVM versions are added.